### PR TITLE
一般ユーザーがsudoを出来るようにコードを追加致しました。

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends libpq-dev=13.4-1.pgdg20.04+1 \
+    && apt-get install -y --no-install-recommends libpq-dev=14.0-1.pgdg20.04+1 \
     && apt-get remove -y lsb-release gnupg \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -15,6 +15,11 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
+# sudoで実行時コマンドが見つからないエラーが出る場合があったので、/etc/sudoersの env_reset オプションをjovyanのみ無効化
+# jovyanがパスワードの確認無しで全てのコマンドを実行できる文言を/etc/sudoersに追記
+RUN echo "Defaults:jovyan !env_reset" /etc/sudoers &&\
+    echo "jovyan  ALL=(ALL) NOPASSWD : ALL" >> /etc/sudoers
+    
 USER jovyan
 WORKDIR /home/jovyan
 COPY Pipfile .


### PR DESCRIPTION
お疲れ様です。
一般ユーザーのjovyanがsudoを使用する際にパスワードなしで行えるようにcodeを追加いたしました。
またコメントにも記載させて頂きましたが、sudoを使用の際に{command not found}というエラーが発生する場合がありました。
原因は環境変数が引き継がれなくPATHが初期化される場合があるとのことでした。
なのでenv_resetをjovyanのみ無効化して環境変数を引き継がせるという対策を取らせて頂きました。
お手数をおかけしますが、またお手すきの際にレビュー頂ければ幸いです。
宜しくお願い致します。